### PR TITLE
fix: syntax error in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ import React from 'react';
 import {schema} from 'prosemirror-schema-basic';
 import {useProseMirror, ProseMirror} from 'use-prosemirror';
 
-return function MyEditor() {
+export function MyEditor() {
     const [state, setState] = useProseMirror({schema});
     return <ProseMirror state={state} onChange={setState} />;
 };


### PR DESCRIPTION
In the line 67 on `README.md` file instead of exporting a function there is a `return` statement which in copying and pasting the code makes it annoying